### PR TITLE
Add 1.21 R1 compatibility layer

### DIFF
--- a/core/src/main/java/me/deadlight/ezchestshop/utils/FloatingItem.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/FloatingItem.java
@@ -16,18 +16,35 @@ public class FloatingItem {
     static VersionUtils versionUtils;
 
     static {
-        try {
+        VersionUtils loaded = null;
 
-            if (Utils.isFolia()) {
-                versionUtils = (VersionUtils) Class.forName("me.deadlight.ezchestshop.utils.v1_20_R3").newInstance();
-
-            } else {
+        if (Utils.isFolia()) {
+            loaded = instantiate("me.deadlight.ezchestshop.utils.v1_21_R1");
+            if (loaded == null) {
+                loaded = instantiate("me.deadlight.ezchestshop.utils.v1_20_R3");
+            }
+        } else {
+            try {
                 String packageName = Utils.class.getPackage().getName();
                 String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-                versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+                loaded = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException ignored) {
+                // logged below if loading fails
             }
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException exception) {
+        }
+
+        if (loaded == null) {
             Bukkit.getLogger().log(Level.SEVERE, "EzChestShop could not find a valid implementation for this server version.");
+        } else {
+            versionUtils = loaded;
+        }
+    }
+
+    private static VersionUtils instantiate(String className) {
+        try {
+            return (VersionUtils) Class.forName(className).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException ignored) {
+            return null;
         }
     }
 

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/ImprovedOfflinePlayer.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/ImprovedOfflinePlayer.java
@@ -14,17 +14,37 @@ public abstract class ImprovedOfflinePlayer {
     public static ImprovedOfflinePlayer improvedOfflinePlayer;
 
     static {
-        try {
+        ImprovedOfflinePlayer loaded = null;
 
-            if (Utils.isFolia()) {
-                improvedOfflinePlayer = (ImprovedOfflinePlayer) Class.forName("me.deadlight.ezchestshop.utils.ImprovedOfflinePlayer_v1_20_R3").newInstance();
-            } else {
+        if (Utils.isFolia()) {
+            loaded = instantiate("me.deadlight.ezchestshop.utils.ImprovedOfflinePlayer_v1_21_R1");
+            if (loaded == null) {
+                loaded = instantiate("me.deadlight.ezchestshop.utils.ImprovedOfflinePlayer_v1_20_R3");
+            }
+        } else {
+            try {
                 String packageName = Utils.class.getPackage().getName();
                 String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-                improvedOfflinePlayer = (ImprovedOfflinePlayer) Class.forName(packageName + ".ImprovedOfflinePlayer_" + internalsName).newInstance();
+                loaded = (ImprovedOfflinePlayer) Class
+                        .forName(packageName + ".ImprovedOfflinePlayer_" + internalsName)
+                        .newInstance();
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException ignored) {
+                // logged below if loading fails
             }
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException exception) {
+        }
+
+        if (loaded == null) {
             Bukkit.getLogger().log(Level.SEVERE, "EzChestShop could not find a valid implementation for this server version.");
+        } else {
+            improvedOfflinePlayer = loaded;
+        }
+    }
+
+    private static ImprovedOfflinePlayer instantiate(String className) {
+        try {
+            return (ImprovedOfflinePlayer) Class.forName(className).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException ignored) {
+            return null;
         }
     }
 

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
@@ -65,18 +65,35 @@ public class Utils {
     public static DatabaseManager databaseManager;
 
     static {
-        try {
-            if (isFolia()) {
-                versionUtils = (VersionUtils) Class.forName("me.deadlight.ezchestshop.utils.v1_20_R3").newInstance();
-            } else {
+        VersionUtils loaded = null;
+        if (isFolia()) {
+            loaded = instantiateVersionUtils("me.deadlight.ezchestshop.utils.v1_21_R1");
+            if (loaded == null) {
+                loaded = instantiateVersionUtils("me.deadlight.ezchestshop.utils.v1_20_R3");
+            }
+        } else {
+            try {
                 String packageName = Utils.class.getPackage().getName();
                 String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-                versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+                loaded = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException ignored) {
+                // logged below if no implementation could be found
             }
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-                | ClassCastException exception) {
+        }
+
+        if (loaded == null) {
             Bukkit.getLogger().log(Level.SEVERE,
                     "EzChestShop could not find a valid implementation for this server version.");
+        } else {
+            versionUtils = loaded;
+        }
+    }
+
+    private static VersionUtils instantiateVersionUtils(String className) {
+        try {
+            return (VersionUtils) Class.forName(className).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException ignored) {
+            return null;
         }
     }
 

--- a/craftbukkit_1_21_R1/pom.xml
+++ b/craftbukkit_1_21_R1/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>me.deadlight</groupId>
+    <artifactId>EzChestShop-craftbukkit_1_21_R1</artifactId>
+    <version>${project.parent.version}</version>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>me.deadlight</groupId>
+        <artifactId>EzChestShop-parent</artifactId>
+        <version>1.6.6</version>
+    </parent>
+
+    <name>EzChestShop-craftbukkit_1_21_R1</name>
+
+    <description>Easy Chest Shop that any server owner wants that for his/her players</description>
+    <properties>
+        <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.md-5</groupId>
+                <artifactId>specialsource-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-obf</id>
+                        <configuration>
+                            <srgIn>org.spigotmc:minecraft-server:1.21-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <reverse>true</reverse>
+                            <remappedDependencies>org.spigotmc:spigot:1.21-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedArtifactAttached>true</remappedArtifactAttached>
+                            <remappedClassifierName>remapped-obf</remappedClassifierName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-spigot</id>
+                        <configuration>
+                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
+                            <srgIn>org.spigotmc:minecraft-server:1.21-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.21-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+            <classifier>remapped-mojang</classifier>
+        </dependency>
+        <dependency>
+            <groupId>me.deadlight</groupId>
+            <artifactId>EzChestShop-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/ChannelHandler_v1_21_R1.java
+++ b/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/ChannelHandler_v1_21_R1.java
@@ -1,0 +1,176 @@
+package me.deadlight.ezchestshop.utils;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import me.deadlight.ezchestshop.EzChestShop;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class ChannelHandler_v1_21_R1 extends ChannelInboundHandlerAdapter {
+
+    private final Player player;
+    private static Field updateSignArrays;
+    private static Method updateSignMethod;
+
+    static {
+        try {
+            updateSignArrays = ServerboundSignUpdatePacket.class.getDeclaredField("c");
+            updateSignArrays.setAccessible(true);
+        } catch (NoSuchFieldException ignored) {
+            // 1.21 may rename the backing field, we will discover it lazily at runtime
+        }
+    }
+
+    public ChannelHandler_v1_21_R1(Player player) {
+        this.player = player;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+
+        if (msg instanceof ServerboundInteractPacket) {
+
+            if (!Utils.enabledOutlines.contains(player.getUniqueId())) {
+                ctx.fireChannelRead(msg);
+                return;
+            }
+
+            //now we check if player is right clicking on the outline shulkerbox, if so we open the shop for them
+            ServerboundInteractPacket packet = (ServerboundInteractPacket) msg;
+            Field field;
+            try {
+                field = packet.getClass().getDeclaredField("a"); //The field a is entity ID
+            } catch (NoSuchFieldException e) {
+                ctx.fireChannelRead(msg);
+                return; //This is for ModelEngine
+            }
+
+            field.setAccessible(true);
+            int entityID = (int) field.get(packet);
+            if (Utils.activeOutlines.containsKey(entityID)) {
+                BlockOutline outline = Utils.activeOutlines.get(entityID);
+                outline.hideOutline();
+                //Then it means somebody is clicking on the outline shulkerbox
+                EzChestShop.getPlugin().getServer().getScheduler().runTaskLater(
+                        EzChestShop.getPlugin(), () -> {
+                            Bukkit.getPluginManager().callEvent(new PlayerInteractEvent(player, Action.RIGHT_CLICK_BLOCK,
+                                    player.getInventory().getItemInMainHand(), outline.block,
+                                    outline.block.getFace(outline.block), null));
+                        }, 1L);
+            }
+        }
+
+        if (msg instanceof ServerboundSignUpdatePacket) {
+            for (Map.Entry<SignMenuFactory, UpdateSignListener> entry : v1_21_R1.getListeners().entrySet()) {
+                UpdateSignListener listener = entry.getValue();
+
+                try {
+                    String[] lines = extractSignText((ServerboundSignUpdatePacket) msg);
+                    if (lines != null) {
+                        listener.listen(player, lines);
+                    }
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    e.printStackTrace();
+                }
+
+                if (listener.isCancelled()) {
+                    ctx.fireChannelRead(msg);
+                    return;
+                }
+            }
+        }
+
+        ctx.fireChannelRead(msg);
+    }
+
+    private String[] extractSignText(ServerboundSignUpdatePacket packet)
+            throws IllegalAccessException, InvocationTargetException {
+        if (updateSignArrays != null) {
+            return (String[]) updateSignArrays.get(packet);
+        }
+
+        if (updateSignMethod != null) {
+            Object result = updateSignMethod.invoke(packet);
+            if (result instanceof String[]) {
+                return (String[]) result;
+            }
+            if (result instanceof List<?>) {
+                return listToArray((List<?>) result);
+            }
+        }
+
+        for (Field field : packet.getClass().getDeclaredFields()) {
+            field.setAccessible(true);
+            if (field.getType().isArray() && field.getType().getComponentType() == String.class) {
+                updateSignArrays = field;
+                return (String[]) field.get(packet);
+            }
+            if (List.class.isAssignableFrom(field.getType())) {
+                Object value = field.get(packet);
+                if (value instanceof List<?>) {
+                    String[] lines = listToArray((List<?>) value);
+                    if (lines != null) {
+                        return lines;
+                    }
+                }
+            }
+        }
+
+        for (Method method : packet.getClass().getDeclaredMethods()) {
+            if (method.getParameterCount() == 0) {
+                Class<?> returnType = method.getReturnType();
+                if (returnType.isArray() && returnType.getComponentType() == String.class) {
+                    method.setAccessible(true);
+                    updateSignMethod = method;
+                    Object result = method.invoke(packet);
+                    return result instanceof String[] ? (String[]) result : null;
+                }
+                if (List.class.isAssignableFrom(returnType)) {
+                    method.setAccessible(true);
+                    updateSignMethod = method;
+                    Object result = method.invoke(packet);
+                    if (result instanceof List<?>) {
+                        return listToArray((List<?>) result);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private String[] listToArray(List<?> list) {
+        if (list == null) {
+            return null;
+        }
+        String[] lines = new String[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            Object element = list.get(i);
+            if (element == null) {
+                lines[i] = "";
+                continue;
+            }
+            if (element instanceof String) {
+                lines[i] = (String) element;
+                continue;
+            }
+            try {
+                Method asString = element.getClass().getMethod("getString");
+                lines[i] = Objects.toString(asString.invoke(element), "");
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) {
+                lines[i] = element.toString();
+            }
+        }
+        return lines;
+    }
+}

--- a/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/ImprovedOfflinePlayer_v1_21_R1.java
+++ b/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/ImprovedOfflinePlayer_v1_21_R1.java
@@ -1,0 +1,109 @@
+package me.deadlight.ezchestshop.utils;
+
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.CompoundTag;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+public class ImprovedOfflinePlayer_v1_21_R1 extends ImprovedOfflinePlayer {
+
+    private File file;
+    private CompoundTag compound;
+
+    public ImprovedOfflinePlayer_v1_21_R1() {
+        super();
+    }
+
+    public ImprovedOfflinePlayer_v1_21_R1(OfflinePlayer player) {
+        super(player);
+    }
+
+    @Override
+    public ImprovedOfflinePlayer fromOfflinePlayer(OfflinePlayer player) {
+        return new ImprovedOfflinePlayer_v1_21_R1(player);
+    }
+
+    @Override
+    public boolean loadPlayerData() {
+        try {
+            for(World w : Bukkit.getWorlds()) {
+                this.file = new File(w.getWorldFolder(), "playerdata" + File.separator + this.player.getUniqueId() + ".dat");
+                if(this.file.exists()){
+                    this.compound = NbtIo.readCompressed(new FileInputStream(this.file), NbtAccounter.unlimitedHeap());
+                    return true;
+                }
+            }
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    public boolean savePlayerData() {
+        if(this.exists) {
+            try {
+                NbtIo.writeCompressed(this.compound, new FileOutputStream(this.file));
+                return true;
+            }
+            catch(Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int getLevel() {
+        if (isOnline) {
+            return player.getPlayer().getLevel();
+        } else {
+            return compound.getInt("XpLevel");
+        }
+    }
+
+    @Override
+    public void setLevel(int level) {
+        if (isOnline) {
+            player.getPlayer().setLevel(level);
+        } else {
+            compound.putInt("XpLevel", level);
+        }
+    }
+
+    @Override
+    public float getExp() {
+        if (isOnline) {
+            return player.getPlayer().getExp();
+        } else {
+            return compound.getFloat("XpP");
+        }
+    }
+
+    @Override
+    public void setExp(float exp) {
+        if (isOnline) {
+            player.getPlayer().setExp(exp);
+        } else {
+            compound.putFloat("XpP", exp);
+        }
+    }
+
+    @Override
+    public int getExpToLevel() {
+        if (isOnline) {
+            return player.getPlayer().getExpToLevel();
+        } else {
+            int level = getLevel();
+            return XPEconomy.getRequiredPointsToLevelUp(level);
+        }
+    }
+
+
+}

--- a/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/MenuOpener_v1_21_R1.java
+++ b/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/MenuOpener_v1_21_R1.java
@@ -1,0 +1,91 @@
+package me.deadlight.ezchestshop.utils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+
+public class MenuOpener_v1_21_R1 {
+
+    private static Constructor<ClientboundBlockEntityDataPacket> constructor;
+
+    static {
+        try {
+            constructor = ClientboundBlockEntityDataPacket.class.getDeclaredConstructor(BlockPos.class, BlockEntityType.class, CompoundTag.class);
+            constructor.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void openMenu(SignMenuFactory.Menu menu, Player player) {
+        Objects.requireNonNull(player, "player");
+        if (!player.isOnline()) {
+            return;
+        }
+
+        Location location = player.getLocation();
+        Location newLocation = location.clone().add(0, 4, 0);
+
+        menu.setLocation(newLocation);
+
+        BlockPos position = new BlockPos(newLocation.getBlockX(), newLocation.getBlockY(), newLocation.getBlockZ());
+
+        player.sendBlockChange(newLocation, Material.OAK_SIGN.createBlockData());
+
+        ClientboundOpenSignEditorPacket editorPacket = new ClientboundOpenSignEditorPacket(position, true);
+
+        CompoundTag compound = new CompoundTag();
+
+        CompoundTag frontText = new CompoundTag();
+        CompoundTag backText = new CompoundTag();
+        ListTag backMessages = new ListTag();
+        ListTag frontMessages = new ListTag();
+
+
+        for (int line = 0; line < SignMenuFactory.SIGN_LINES; line++) {
+            String text = menu.getText().size() > line ? String.format(SignMenuFactory.NBT_FORMAT, menu.color(menu.getText().get(line))) : "";
+            StringTag nbtString = StringTag.valueOf(text);
+
+            // Assuming you want to set the same text for both back and front
+            backMessages.add(nbtString);
+            frontMessages.add(nbtString);
+        }
+
+        backText.put("messages", backMessages);
+        frontText.put("messages", frontMessages);
+        compound.put("back_text", backText);
+        compound.put("front_text", frontText);
+
+
+//        for (int line = 0; line < SignMenuFactory.SIGN_LINES; line++) {
+//            compound.a("Text" + (line + 1), menu.getText().size() > line ? String.format(SignMenuFactory.NBT_FORMAT, menu.color(menu.getText().get(line))) : "");
+//        } no loger works this way in 1.20, we need to use the new method above
+
+
+        ClientboundBlockEntityDataPacket tileEntityDataPacket = null;
+        try {
+            tileEntityDataPacket = constructor.newInstance(position, BlockEntityType.SIGN, compound);
+        } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+
+        connection.send(tileEntityDataPacket);
+        connection.send(editorPacket);
+
+        menu.getFactory().getInputs().put(player, menu);
+    }
+
+}

--- a/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_21_R1.java
+++ b/craftbukkit_1_21_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_21_R1.java
@@ -1,0 +1,246 @@
+package me.deadlight.ezchestshop.utils;
+
+import io.netty.channel.Channel;
+import me.deadlight.ezchestshop.EzChestShop;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.RelativeMovement;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.monster.Shulker;
+import net.minecraft.world.level.Level;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_21_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_21_R1.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class v1_21_R1 extends VersionUtils {
+
+    private static final Map<SignMenuFactory, UpdateSignListener> listeners = new HashMap<>();
+    private static Map<Integer, Entity> entities = new HashMap<>();
+
+    /**
+     * Convert an Item to a Text Compount. Used in Text Component Builders to show
+     * items in chat.
+     *
+     * @category ItemUtils
+     * @param itemStack
+     * @return
+     */
+
+    @Override
+    String ItemToTextCompoundString(ItemStack itemStack) {
+        // First we convert the item stack into an NMS itemstack
+        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
+        CompoundTag compound = new CompoundTag();
+        compound = nmsItemStack.save(compound);
+
+        return compound.toString();
+    }
+
+    @Override
+    int getArmorStandIndex() {
+        return 15;
+    }
+
+    @Override
+    int getItemIndex() {
+        return 8;
+    }
+
+    @Override
+    void destroyEntity(Player player, int entityID) {
+        ((CraftPlayer) player).getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket(entityID));
+        entities.remove(entityID);
+    }
+
+    @Override
+    void spawnHologram(Player player, Location location, String line, int ID) {
+
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        ServerPlayer ServerPlayer = craftPlayer.getHandle();
+        ServerGamePacketListenerImpl ServerGamePacketListenerImpl = ServerPlayer.connection;
+        CraftWorld craftWorld = (CraftWorld) location.getWorld();
+        Level world = craftWorld.getHandle();
+        //------------------------------------------------------
+
+        ArmorStand armorstand = new ArmorStand(world, location.getX(), location.getY(), location.getZ());
+        armorstand.setInvisible(true); //invisible
+        armorstand.setMarker(true); //Marker
+        armorstand.setCustomName(CraftChatMessage.fromStringOrNull(line)); //set custom name
+        armorstand.setCustomNameVisible(true); //make custom name visible
+        armorstand.setNoGravity(true); //no gravity
+        armorstand.setId(ID); //set entity id
+
+        ClientboundAddEntityPacket ClientboundAddEntityPacket = new ClientboundAddEntityPacket(armorstand, 0);
+        ServerGamePacketListenerImpl.send(ClientboundAddEntityPacket);
+        //------------------------------------------------------
+        //create a list of datawatcher objects
+
+        ClientboundSetEntityDataPacket metaPacket = new ClientboundSetEntityDataPacket(ID, armorstand.getEntityData().getNonDefaultValues());
+        ServerGamePacketListenerImpl.send(metaPacket);
+        entities.put(ID, armorstand);
+    }
+
+    @Override
+    void spawnFloatingItem(Player player, Location location, ItemStack itemStack, int ID) {
+
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        ServerPlayer ServerPlayer = craftPlayer.getHandle();
+        ServerGamePacketListenerImpl ServerGamePacketListenerImpl = ServerPlayer.connection;
+        CraftWorld craftWorld = (CraftWorld) location.getWorld();
+        Level world = craftWorld.getHandle();
+        //------------------------------------------------------
+
+        ItemEntity floatingItem = new ItemEntity(world, location.getX(), location.getY(), location.getZ(), CraftItemStack.asNMSCopy(itemStack));
+        floatingItem.setNoGravity(true); //no gravity
+        floatingItem.setId(ID); //set entity id
+        floatingItem.setDeltaMovement(0, 0, 0); //set velocity
+
+        ClientboundAddEntityPacket ClientboundAddEntityPacket = new ClientboundAddEntityPacket(floatingItem, 0);
+        ServerGamePacketListenerImpl.send(ClientboundAddEntityPacket);
+        //------------------------------------------------------
+        // sending meta packet
+        ClientboundSetEntityDataPacket metaPacket = new ClientboundSetEntityDataPacket(ID, floatingItem.getEntityData().getNonDefaultValues());
+        ServerGamePacketListenerImpl.send(metaPacket);
+
+        //sending a velocity packet
+        floatingItem.setDeltaMovement(0, 0, 0);
+        ClientboundSetEntityMotionPacket velocityPacket = new ClientboundSetEntityMotionPacket(floatingItem);
+        ServerGamePacketListenerImpl.send(velocityPacket);
+        entities.put(ID, floatingItem);
+    }
+
+    void renameEntity(Player player, int entityID, String newName) {
+        try {
+            // the entity only exists on the client, how can I get it?
+            Entity e = entities.get(entityID);
+            e.setCustomName(CraftChatMessage.fromStringOrNull(newName));
+            ClientboundSetEntityDataPacket packet = new ClientboundSetEntityDataPacket(entityID, e.getEntityData().getNonDefaultValues());
+            ((CraftPlayer) player).getHandle().connection.send(packet);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void teleportEntity(Player player, int entityID, Location location) {
+        ServerPlayer ServerPlayer = ((CraftPlayer) player).getHandle();
+        Entity e = entities.get(entityID);
+        Set<RelativeMovement> set = new HashSet<>();
+        e.teleportTo(ServerPlayer.serverLevel(), location.getX(), location.getY(), location.getZ(), set, 0, 0);
+        // not sure if it's needed
+        ClientboundTeleportEntityPacket packet = new ClientboundTeleportEntityPacket(e);
+        ServerPlayer.connection.send(packet);
+    }
+
+    @Override
+    void signFactoryListen(SignMenuFactory signMenuFactory) {
+
+        listeners.put(signMenuFactory, new UpdateSignListener() {
+            @Override
+            public void listen(Player player, String[] array) {
+
+                SignMenuFactory.Menu menu = signMenuFactory.getInputs().remove(player);
+
+                if (menu == null) {
+                    return;
+                }
+                setCancelled(true);
+
+                boolean success = menu.getResponse().test(player, array);
+
+                if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                }
+
+                removeSignMenuFactoryListen(signMenuFactory);
+
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                    if (player.isOnline()) {
+                        Location location = menu.getLocation();
+                        player.sendBlockChange(location, location.getBlock().getBlockData());
+                    }
+                }, 2L);
+
+
+            }
+        });
+
+    }
+
+    @Override
+    void removeSignMenuFactoryListen(SignMenuFactory signMenuFactory) {
+
+        listeners.remove(signMenuFactory);
+
+    }
+
+    @Override
+    void openMenu(SignMenuFactory.Menu menu, Player player) {
+        MenuOpener_v1_21_R1.openMenu(menu, player);
+    }
+
+    @Override
+    public void injectConnection(Player player) throws IllegalAccessException, NoSuchFieldException {
+        Connection netManager = ((CraftPlayer) player).getHandle().connection.connection;
+        netManager.channel.pipeline().addBefore("packet_handler", "ecs_listener", new ChannelHandler_v1_21_R1(player));
+    }
+
+    @Override
+    public void ejectConnection(Player player) throws NoSuchFieldException, IllegalAccessException {
+        Connection netManager = ((CraftPlayer) player).getHandle().connection.connection;
+        Channel channel = netManager.channel;
+        channel.eventLoop().submit(() -> channel.pipeline().remove("ecs_listener"));
+    }
+
+    @Override
+    void showOutline(Player player, Block block, int eID) {
+        ServerLevel ServerLevel = ((CraftWorld) block.getLocation().getWorld()).getHandle();
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        ServerPlayer ServerPlayer = craftPlayer.getHandle();
+        ServerGamePacketListenerImpl ServerGamePacketListenerImpl = ServerPlayer.connection;
+
+        Shulker shulker = new Shulker(EntityType.SHULKER, ServerLevel);
+        shulker.setInvisible(true); //invisible
+        shulker.setNoGravity(true); //no gravity
+        shulker.setDeltaMovement(0, 0, 0); //set velocity
+        shulker.setId(eID); //set entity id
+        shulker.setGlowingTag(true); //set outline
+        shulker.setNoAi(true); //set noAI
+        Location newLoc = block.getLocation().clone();
+        //make location be center of the block vertically and horizontally
+        newLoc.add(0.5, 0, 0.5);
+        shulker.setPos(newLoc.getX(), newLoc.getY(), newLoc.getZ()); //set position
+
+        ClientboundAddEntityPacket spawnPacket = new ClientboundAddEntityPacket(shulker);
+        ServerGamePacketListenerImpl.send(spawnPacket);
+
+        ClientboundSetEntityDataPacket metaPacket = new ClientboundSetEntityDataPacket(eID, shulker.getEntityData().getNonDefaultValues());
+        ServerGamePacketListenerImpl.send(metaPacket);
+
+    }
+
+    public static Map<SignMenuFactory, UpdateSignListener> getListeners() {
+        return listeners;
+    }
+
+
+}

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         <dependency>
             <groupId>me.deadlight</groupId>
+            <artifactId>EzChestShop-craftbukkit_1_21_R1</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.deadlight</groupId>
             <artifactId>EzChestShop-craftbukkit_1_20_R3</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>craftbukkit_1_18_R2</module>
         <module>craftbukkit_1_19_R3</module>
         <module>craftbukkit_1_20_R3</module>
+        <module>craftbukkit_1_21_R1</module>
         <module>dist</module>
     </modules>
 </project>


### PR DESCRIPTION
## Summary
- add a new craftbukkit_1_21_R1 module with the NMS hooks required for Minecraft 1.21 servers
- update shared utilities to detect the 1.21 implementation while keeping a 1.20 fallback for Folia environments
- include the new module in the aggregated build so the shaded jar contains 1.21 support

## Testing
- mvn -pl craftbukkit_1_21_R1 -am package -DskipTests *(fails: unable to download Maven plugins in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2578518f4832eafe21255bb2c40f0